### PR TITLE
Fix segment rollback when reversing at terminus

### DIFF
--- a/src/server/MapBroadcaster.server.ts
+++ b/src/server/MapBroadcaster.server.ts
@@ -197,10 +197,11 @@ RunService.Heartbeat.Connect(() => {
 		//   t ≈ 0   -> represent as the *end of previous segment* (seg-1, t=1)
 		//   t ≈ 1   -> represent as the *end of current segment* (seg,   t=1)
 		// EXCEPTION: Don't move backwards if we're at a terminus position
+		const atForwardTerminus = state.direction === "reverse" && state.lastSeg >= maxSegments && bestT <= EPS;
 		const isAtOriginTerminus = bestSeg === 1 && bestT <= EPS;
 		const isAtEndTerminus = bestSeg === maxSegments && bestT >= 1 - EPS;
 
-		if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus) {
+		if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus && !atForwardTerminus) {
 			bestSeg = bestSeg - 1;
 			bestT = 1.0;
 		} else if (bestT >= 1 - EPS) {
@@ -211,6 +212,12 @@ RunService.Heartbeat.Connect(() => {
 		if (isAtOriginTerminus) {
 			bestSeg = 1;
 			bestT = 0.0;
+		} else if (atForwardTerminus) {
+			bestSeg = maxSegments;
+			bestT = 0.0;
+			if (shapeKey === "R026" && math.floor(tick()) % 2 === 0) {
+				print(`DEBUG: ${name} held at forward terminus after reversal`);
+			}
 		} else if (isAtEndTerminus) {
 			bestSeg = maxSegments;
 			bestT = 1.0;

--- a/src/server/RouteSpawner.ts
+++ b/src/server/RouteSpawner.ts
@@ -422,11 +422,12 @@ function broadcastAITrainPosition(
 	const maxSegments = waypoints.size() - 1; // For R026: 4 waypoints -> 3 segments
 	const EPS = 1e-4;
 
-	// Handle terminus positions properly
+	// Detect terminus conditions before any segment rollback
+	const atForwardTerminus = state.direction === "reverse" && state.waypointIndex === maxIndex && bestT <= EPS;
 	const isAtOriginTerminus = bestSeg === 1 && bestT <= EPS;
 	const isAtEndTerminus = bestSeg >= maxSegments && bestT >= 1 - EPS;
 
-	if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus) {
+	if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus && !atForwardTerminus) {
 		bestSeg = bestSeg - 1;
 		bestT = 1.0;
 	} else if (bestT >= 1 - EPS) {
@@ -437,6 +438,10 @@ function broadcastAITrainPosition(
 	if (isAtOriginTerminus) {
 		bestSeg = 1;
 		bestT = 0.0;
+	} else if (atForwardTerminus) {
+		bestSeg = maxSegments;
+		bestT = 0.0;
+		print(`DEBUG: Train ${trainName} held at forward terminus after reversal`);
 	} else if (isAtEndTerminus) {
 		bestSeg = maxSegments;
 		bestT = 1.0;


### PR DESCRIPTION
## Summary
- Avoid segment rollback when a reversed train sits at the forward terminus
- Guard MapBroadcaster canonicalization against backward teleportation during reversal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7808d06c832da121a8439fcca6b7