### PR TITLE
fix: prevent segment rollback at terminus

### DIFF
--- a/src/server/MapBroadcaster.server.ts
+++ b/src/server/MapBroadcaster.server.ts
@@ -198,9 +198,10 @@ RunService.Heartbeat.Connect(() => {
 		//   t ≈ 1   -> represent as the *end of current segment* (seg,   t=1)
 		// EXCEPTION: Don't move backwards if we're at a terminus position
 		const isAtOriginTerminus = bestSeg === 1 && bestT <= EPS;
-		const isAtEndTerminus = bestSeg === maxSegments && bestT >= 1 - EPS;
+		const isAtEndTerminus =
+			bestSeg === maxSegments && (bestT >= 1 - EPS || (state.direction === "reverse" && bestT <= EPS));
 
-		if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus) {
+		if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus && !isAtEndTerminus) {
 			bestSeg = bestSeg - 1;
 			bestT = 1.0;
 		} else if (bestT >= 1 - EPS) {
@@ -213,7 +214,7 @@ RunService.Heartbeat.Connect(() => {
 			bestT = 0.0;
 		} else if (isAtEndTerminus) {
 			bestSeg = maxSegments;
-			bestT = 1.0;
+			bestT = state.direction === "reverse" ? 0.0 : 1.0;
 		}
 
 		state.lastSeg = bestSeg;

--- a/src/server/RouteSpawner.ts
+++ b/src/server/RouteSpawner.ts
@@ -424,9 +424,10 @@ function broadcastAITrainPosition(
 
 	// Handle terminus positions properly
 	const isAtOriginTerminus = bestSeg === 1 && bestT <= EPS;
-	const isAtEndTerminus = bestSeg >= maxSegments && bestT >= 1 - EPS;
+	const isAtEndTerminus =
+		bestSeg >= maxSegments && (bestT >= 1 - EPS || (state.direction === "reverse" && bestT <= EPS));
 
-	if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus) {
+	if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus && !isAtEndTerminus) {
 		bestSeg = bestSeg - 1;
 		bestT = 1.0;
 	} else if (bestT >= 1 - EPS) {
@@ -439,7 +440,7 @@ function broadcastAITrainPosition(
 		bestT = 0.0;
 	} else if (isAtEndTerminus) {
 		bestSeg = maxSegments;
-		bestT = 1.0;
+		bestT = state.direction === "reverse" ? 0.0 : 1.0;
 	}
 
 	// Build station ETAs (simplified for AI trains)


### PR DESCRIPTION
## Summary
- avoid moving trains back a segment when reversing at a terminus
- canonicalize terminus positions for both AI and player trains without jumping

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7808d06c832da121a8439fcca6b7