### PR TITLE
Fix train teleport on terminus reversal

### DIFF
--- a/src/server/MapBroadcaster.server.ts
+++ b/src/server/MapBroadcaster.server.ts
@@ -197,10 +197,14 @@ RunService.Heartbeat.Connect(() => {
 		//   t ≈ 0   -> represent as the *end of previous segment* (seg-1, t=1)
 		//   t ≈ 1   -> represent as the *end of current segment* (seg,   t=1)
 		// EXCEPTION: Don't move backwards if we're at a terminus position
-		const isAtOriginTerminus = bestSeg === 1 && bestT <= EPS;
-		const isAtEndTerminus = bestSeg === maxSegments && bestT >= 1 - EPS;
+		const isAtOriginTerminus =
+			bestSeg === 1 &&
+			((state.direction === "forward" && bestT <= EPS) || (state.direction === "reverse" && bestT >= 1 - EPS));
+		const isAtEndTerminus =
+			bestSeg === maxSegments &&
+			((state.direction === "forward" && bestT >= 1 - EPS) || (state.direction === "reverse" && bestT <= EPS));
 
-		if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus) {
+		if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus && !isAtEndTerminus) {
 			bestSeg = bestSeg - 1;
 			bestT = 1.0;
 		} else if (bestT >= 1 - EPS) {

--- a/src/server/RouteSpawner.ts
+++ b/src/server/RouteSpawner.ts
@@ -422,11 +422,18 @@ function broadcastAITrainPosition(
 	const maxSegments = waypoints.size() - 1; // For R026: 4 waypoints -> 3 segments
 	const EPS = 1e-4;
 
-	// Handle terminus positions properly
-	const isAtOriginTerminus = bestSeg === 1 && bestT <= EPS;
-	const isAtEndTerminus = bestSeg >= maxSegments && bestT >= 1 - EPS;
+	// Detect whether we're precisely at either terminus. When reversing at the
+	// forward terminus the train's t resets to 0, so we explicitly treat that
+	// as still being at the end terminus before any canonicalization occurs.
+	const isAtOriginTerminus =
+		bestSeg === 1 &&
+		((state.direction === "forward" && bestT <= EPS) || (state.direction === "reverse" && bestT >= 1 - EPS));
 
-	if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus) {
+	const isAtEndTerminus =
+		bestSeg >= maxSegments &&
+		((state.direction === "forward" && bestT >= 1 - EPS) || (state.direction === "reverse" && bestT <= EPS));
+
+	if (bestT <= EPS && bestSeg > 1 && !isAtOriginTerminus && !isAtEndTerminus) {
 		bestSeg = bestSeg - 1;
 		bestT = 1.0;
 	} else if (bestT >= 1 - EPS) {


### PR DESCRIPTION
## Summary
- prevent segment rollback when reversing at terminus
- detect terminus positions using direction-aware checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c7808d06c832da121a8439fcca6b7